### PR TITLE
Make sure token key does not start or end with a . or - characters

### DIFF
--- a/tokens/token_util.go
+++ b/tokens/token_util.go
@@ -28,7 +28,10 @@ func generateKey() (string, error) {
 func sanitizeKey(key string) string {
 	re := regexp.MustCompile("[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*")
 	submatches := re.FindAllString(key, -1)
-	return strings.Join(submatches, "")
+	submatchJoin := strings.Join(submatches, "")
+	submatchJoin = strings.Trim(submatchJoin, "-")
+	submatchJoin = strings.Trim(submatchJoin, ".")
+	return submatchJoin
 }
 
 func getAuthProviderName(principalID string) string {


### PR DESCRIPTION
@cjellick this is for the issue seen by @ibuildthecloud:

curl -s -X POST -d '{"localCredential": {"userName": "admin", "password": "admin"}, "responseType": "json"}' http://localhost:1234/v3/tokens?action=login | jq .
{
  "type": "error",
  "status": "500",
  "message": "Token.management.cattle.io \"e5t3fil1w5kme5murydwlt3vxnnadjuqfcf4wk3-\" is invalid: metadata.name: Invalid value: \"e5t3fil1w5kme5murydwlt3vxnnadjuqfcf4wk3-\": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"
}