### PR TITLE
Fallback to client when looking up token

### DIFF
--- a/authenticator/authenticate.go
+++ b/authenticator/authenticate.go
@@ -13,7 +13,8 @@ type Authenticator interface {
 
 func NewAuthenticator(ctx context.Context, mgmtCtx *config.ManagementContext) Authenticator {
 	return &tokenAuthenticator{
-		ctx:    ctx,
-		tokens: mgmtCtx.Management.Tokens("").Controller().Lister(),
+		ctx:         ctx,
+		tokens:      mgmtCtx.Management.Tokens("").Controller().Lister(),
+		tokenClient: mgmtCtx.Management.Tokens(""),
 	}
 }


### PR DESCRIPTION
First use the cache, if not found there, make an explicit call with
the client